### PR TITLE
about usのスマホ対応

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,7 +35,7 @@ export default function Home() {
           </a>
         </div>
       </div>
-      <div className="my-5 flex justify-center">
+      <div className="my-5 flex justify-center flex-col md:flex-row items-center">
         <Link href="/sponsor-recruitment">
           <button className="btn lg:btn-lg font-bold  btn-accent m-1 btn-wide">
             スポンサー募集


### PR DESCRIPTION
スポンサー募集とプロポーザル募集のボタンが、スマホの時は崩れてしまっていたため、調整する修正