### PR TITLE
NavBarにブログリンクを追加

### DIFF
--- a/app/lib/data.tsx
+++ b/app/lib/data.tsx
@@ -1,7 +1,7 @@
 import type { PageInfo, QandA, CardData } from "./definitions";
 import { HiHome } from "react-icons/hi";
 import { HiLightBulb } from "react-icons/hi2";
-import { FaHandshake } from "react-icons/fa";
+import { FaHandshake, FaBook } from "react-icons/fa";
 import { FaXTwitter, FaInstagram, FaFacebookF } from "react-icons/fa6";
 
 export const pageInfos: PageInfo[] = [
@@ -27,6 +27,13 @@ export const pageInfos: PageInfo[] = [
       "TSKaigiは日本のTypeScriptコミュニティを盛り上げるカンファレンスを開催します。あなたの発表・登壇をお待ちしております。ぜひ一緒に日本のTypeScriptコミュニティを盛り上げましょう！",
     icon: HiLightBulb,
     href: "/call-for-proposals",
+  },
+  {
+    index: 4,
+    title: "Blog",
+    description: "TSKaigi運営のブログ",
+    icon: FaBook,
+    href: "https://tskaigi.hatenablog.com/",
   },
 ];
 


### PR DESCRIPTION
NavBar にブログリンクを追加しました。

pageInfos に外部のリンクを追加して良いものか悩ましく思ったものの暫定でこちらの改修しています。
また、NavBar内の表示順に関しても迷いつつも index を壊すと、どこかが壊れそうであったため最後尾に追加しています。

<img width="1200" alt="image" src="https://github.com/tskaigi/tskaigi.github.io/assets/33322961/be229e20-5010-4c82-b5c6-86b77defb3f5">
