### PR TITLE
チケット販売のページをEventhubへリンクさせる

### DIFF
--- a/app/lib/data.tsx
+++ b/app/lib/data.tsx
@@ -124,3 +124,5 @@ export const selectionCommittee: CardData[] = [
     links: [{ icon: FaXTwitter, href: "https://twitter.com/uhyo_" }],
   },
 ];
+
+export const ticketURL = "https://client.eventhub.jp/ticket/VjqcjZK60";

--- a/app/ui/footer.tsx
+++ b/app/ui/footer.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { PageInfo } from "../lib/definitions";
-import { pageInfos } from "../lib/data";
+import { pageInfos, ticketURL } from "../lib/data";
 import { HiExternalLink } from "react-icons/hi";
 
 export default function Footer() {
@@ -37,12 +37,12 @@ export default function Footer() {
       <nav>
         <header className="footer-title">チケット購入</header>
         <Link
-          href={"/"}
+          href={ticketURL}
           rel="noopener noreferrer"
           target="_blank"
-          className="flex items-center gap-2 pl-2 pointer-events-none cursor-not-allowed opacity-50"
+          className="flex items-center gap-2 pl-2"
         >
-          チケット購入(Coming soon)
+          チケット購入
           <HiExternalLink />
         </Link>
       </nav>


### PR DESCRIPTION
チケット販売のページをEventhubで作成したので、そちらにURLを向くように変更しました。

販売ページ
https://client.eventhub.jp/ticket/VjqcjZK60