### PR TITLE
fix: anchor management

### DIFF
--- a/app/components/SponsorLogosSection.tsx
+++ b/app/components/SponsorLogosSection.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { sponsorList } from '../lib/data';
 import Link from 'next/link';
 import { SponsorData, SponsorList } from '../lib/definitions';
-import { pageAnchors } from '../page';
 
 const sponsorVariants = {
   Platinum: {
@@ -50,14 +49,14 @@ const sponsorVariants = {
 
 type SponsorLogosSectionProps = {
   showDraft: boolean;
-
+  anchor: string
 }
 
-export const SponsorLogosSection = ({showDraft}: SponsorLogosSectionProps) => {
+export const SponsorLogosSection = ({showDraft, anchor}: SponsorLogosSectionProps) => {
   return (
       <div className="py-20">
         <div className="max-w-4xl mx-auto">
-          <h2 id={pageAnchors.sponsor} className="text-2xl font-bold text-center text-accent lg:text-3xl mb-20 scroll-mt-20">
+          <h2 id={anchor} className="text-2xl font-bold text-center text-accent lg:text-3xl mb-20 scroll-mt-20">
             <a href="#sponsor">TSKaigi 2024 スポンサー各社</a>
           </h2>
         </div>

--- a/app/draft/page.tsx
+++ b/app/draft/page.tsx
@@ -3,7 +3,12 @@ import { HiExternalLink } from "react-icons/hi";
 import { SponsorLogosSection } from '../components/SponsorLogosSection'
 import Container from "../ui/container";
 import { NavigateAnchorOnFirstRender } from "../functional/navigate-anchor-on-first-render";
-import { pageAnchors } from "../page";
+
+const pageAnchors = {
+  news: 'news',
+  ticketInfo: 'ticket-info',
+  sponsor: 'sponsor',
+}
 
 export default function DraftTopPage () {
   return (
@@ -80,7 +85,7 @@ export default function DraftTopPage () {
           </div>
         </div>
       </Container>
-      <SponsorLogosSection showDraft/>
+      <SponsorLogosSection anchor={pageAnchors.sponsor} showDraft/>
     </>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,14 +2,12 @@ import Link from "next/link";
 import Container from "./ui/container";
 import { HiExternalLink } from "react-icons/hi";
 import { NavigateAnchorOnFirstRender } from "./functional/navigate-anchor-on-first-render";
-import { SponsorLogosSection } from "./components/SponsorLogosSection";
 
-export const pageAnchors = {
+const pageAnchors = {
   news: 'news',
   ticketInfo: 'ticket-info',
   sponsor: 'sponsor',
 }
-
 
 export default function Home() {
   return (


### PR DESCRIPTION
- page.tsxからの定数のexportがNext.jsのルール上できなかったので、個別に定義する方法に変更
- SponsorLogosSection が anchor を props 経由で取得するように変更