### PR TITLE
個人スポンサーの追加

### DIFF
--- a/app/components/PersonalSponsorSection.tsx
+++ b/app/components/PersonalSponsorSection.tsx
@@ -46,6 +46,42 @@ const PersonalSponsors = [
     image: "https://avatars.githubusercontent.com/u/4058100?v=4",
     href: "https://github.com/km-tr",
   },
+
+  {
+    name: "yug1224",
+    image: "https://avatars.githubusercontent.com/u/3946829?v=4",
+    href: "https://github.com/yug1224",
+  },
+  {
+    name: "Natsuki",
+    image: "https://pbs.twimg.com/profile_images/1769222039892828160/e7oPJcnp_400x400.png",
+    href: "https://twitter.com/natch_engr/",
+  },
+  {
+    name: "たっつー",
+    image: "https://avatars.githubusercontent.com/u/19267812?v=4",
+    href: "https://twitter.com/tatsutakein",
+  },
+  {
+    name: "ryu",
+    image: "https://avatars.githubusercontent.com/u/114303361?v=4",
+    href: "https://ryu.app/",
+  },
+  {
+    name: "みっちー",
+    image: "https://pbs.twimg.com/profile_images/1729293030228938752/4CY9EWBi_400x400.jpg",
+    href: "https://twitter.com/michiya_nishida",
+  },
+  {
+    name: "黒柳シャチ子",
+    image: "https://pbs.twimg.com/profile_images/1766252367098544128/Z7tjsCWl_400x400.jpg",
+    href: "https://twitter.com/shachi_daikon55",
+  },
+  {
+    name: "河豚田(wataru_fujita)",
+    image: "https://pbs.twimg.com/profile_images/1462746900902604804/2_tWSoay_400x400.jpg",
+    href: "https://twitter.com/fujitagoikka",
+  },
 ] as const;
 
 const StaffCard = (props: (typeof PersonalSponsors)[number]) => {


### PR DESCRIPTION
以下の個人スポンサーの方々追加しました(敬称略)
- yug1224
- Natsuki
- たっつー
- ryu
- みっちー
- 黒柳シャチ子
- 河豚田(wataru_fujita)

<img width="794" alt="スクリーンショット 2024-04-04 12 54 49" src="https://github.com/tskaigi/tskaigi.github.io/assets/77495217/8fdbb801-41fa-4b2d-8b06-7ea0d991125e">

