### PR TITLE
スポンサー募集が終了したので、応募ボタンを削除

### DIFF
--- a/app/components/SponsorPage.tsx
+++ b/app/components/SponsorPage.tsx
@@ -145,7 +145,7 @@ export default function SponsorPage({ showDraft }: SponsorPageProps) {
               <span className=" lg:text-6xl text-accent pr-4">
                 TSKaigi 2024 <br />
               </span>
-              はスポンサーを募集しています
+              スポンサーの募集は終了しました。
             </h1>
           </div>
         </div>

--- a/app/components/SponsorPage.tsx
+++ b/app/components/SponsorPage.tsx
@@ -161,12 +161,16 @@ export default function SponsorPage({ showDraft }: SponsorPageProps) {
               ></iframe>
             </div>
           </div>
-          <Cta
-            subLink="https://forms.gle/aZnQSAz8UEwdiitj7"
-            subLinkText="お問い合わせ"
-            mainLink="https://forms.gle/ERgp32CP8q7ZTc8h8"
-            mainLinkText="応募する"
-          />
+          <div className="flex justify-center mt-8">
+            <a
+              href="https://forms.gle/aZnQSAz8UEwdiitj7"
+              rel="noopener noreferrer"
+              target="_blank"
+              className="link link-primary"
+            >
+              <div className="btn lg:btn-md ">お問い合わせ</div>
+            </a>
+          </div>
         </div>
       </Container>
     </div>


### PR DESCRIPTION
- 見出しの文言変更
- 応募ボタンを削除

問い合わせはもしかしたらあるかもなので、そのままにしています。
案内資料についても、応募済みのスポンサー様が見ている可能性があるので、念の為置いています。（もし非公開にした方がよければ削除します）

<img width="600" alt="image" src="https://github.com/tskaigi/tskaigi.github.io/assets/38308823/634018f5-2b11-4a3d-9cb7-82f1c41ed770">


<img width="300" alt="image" src="https://github.com/tskaigi/tskaigi.github.io/assets/38308823/f610a139-4ed1-45a8-b878-cc4e88beb364">
