### PR TITLE
個人スポンサーの更新

### DIFF
--- a/app/components/PersonalSponsorSection.tsx
+++ b/app/components/PersonalSponsorSection.tsx
@@ -2,8 +2,8 @@ import Link from "next/link";
 
 const PersonalSponsors = [
   {
-    name: "大石 貴則 (おおいし)",
-    image: "	https://pbs.twimg.com/profile_images/1671084783122907139/ovRsFdyJ_400x400.jpg",
+    name: "おおいし (bicstone)",
+    image: "https://pbs.twimg.com/profile_images/1671084783122907139/ovRsFdyJ_400x400.jpg",
     href: "https://bicstone.me/",
   },
   {


### PR DESCRIPTION
外部から失礼いたします。個人スポンサーとして登録させて頂いたbicstoneと申します。
他の個人スポンサーの方で本名書いている方がおらず、トンマナを揃えるためにハンドルネームに変更しました。
お手すきのタイミングでマージ頂けると幸いです。

※ EventHubのプロフィール(`掲載する名前（ハンドルネーム可）`)も修正しております。

| 修正前 | 修正後 |
| -- | -- |
| ![tskaigi org_ (1)](https://github.com/tskaigi/tskaigi.github.io/assets/47806818/e5e148ab-c632-4b77-acf0-8730962cb129) | ![localhost_3000_](https://github.com/tskaigi/tskaigi.github.io/assets/47806818/17fda159-f40f-4c44-84f0-d32d1d1891de) |
