### PR TITLE
Remove draft flag from Luup

### DIFF
--- a/app/lib/data.tsx
+++ b/app/lib/data.tsx
@@ -746,7 +746,6 @@ EventHubは、マーケティング、営業のためのウェビナー・カン
         { href: "", text: "" },
       ],
       addPadding: false,
-      draft: true,
     },
     {
       name: "",


### PR DESCRIPTION
`draft` flag を削除して, 株式会社Luup様のロゴを公開します.