### PR TITLE
サブイベントのサムネイルがSafariにおいて縦に引き伸ばされる問題を修正

### DIFF
--- a/app/subevents/page.tsx
+++ b/app/subevents/page.tsx
@@ -42,7 +42,7 @@ const SubEventPage = () => {
                 </h2>
               </a>
               <a href={link} target="_blank" rel="noopener noreferrer">
-                <img src={thumbnail} alt={title} className="mt-4 h-full max-h-[200px]" />
+                <img src={thumbnail} alt={title} className="mt-4 max-h-[200px]" />
               </a>
               <p className="mt-4 whitespace-pre-line">{description}</p>
               <div className="mt-4 flex flex-wrap gap-2">


### PR DESCRIPTION
[Subevents](https://tskaigi.org/subevents)のサムネイルがSafariにおいて縦に引き伸ばされる問題を修正しました。

## 背景

現在の本番環境において、Safari最新版(Mac, iPhone)において、ウインドウ横幅を約400px以下にしても、画像の縦幅が200pxに固定され縦長に伸びる問題が発生しています。

今回のケースだと `height:100%` が不要なため、削除しました。

## 動作確認

| デバイス | 変更前 (現在の本番環境) | 変更後 (このPRを適用後) |
| -- | -- | -- |
| Mac | ![1](https://github.com/tskaigi/tskaigi.github.io/assets/47806818/2e62d9f1-343d-4aef-a985-6392463725e6) | ![2](https://github.com/tskaigi/tskaigi.github.io/assets/47806818/6f1e46cd-2f82-419a-a366-5ee151ae057a) |
| iPhone | ![3](https://github.com/tskaigi/tskaigi.github.io/assets/47806818/c5f09324-02db-4fb6-a5cb-a4552ec85bbf) | ![4](https://github.com/tskaigi/tskaigi.github.io/assets/47806818/46f0f235-ea1e-4e48-9dfb-124aa689b4cf) |




